### PR TITLE
add 'service' to the configuration and use the value for requests instead of hardcoded "aps"

### DIFF
--- a/sigv4_config.go
+++ b/sigv4_config.go
@@ -28,6 +28,7 @@ type SigV4Config struct {
 	SecretKey          config.Secret `yaml:"secret_key,omitempty"`
 	Profile            string        `yaml:"profile,omitempty"`
 	RoleARN            string        `yaml:"role_arn,omitempty"`
+	Service            string        `yaml:"service,omitempty"`
 	UseFIPSSTSEndpoint bool          `yaml:"use_fips_sts_endpoint,omitempty"`
 }
 

--- a/testdata/sigv4_good.yaml
+++ b/testdata/sigv4_good.yaml
@@ -1,6 +1,7 @@
 region: us-east-2
 access_key: AccessKey
 secret_key: SecretKey
+service: execute-api
 profile: profile
 role_arn: blah:role/arn
 use_fips_sts_endpoint: true


### PR DESCRIPTION
👋 Hello!

## Changes:
- add 'service' to the sigv4 configuration
- read value from configuration when making request, otherwise default to 'aps' as it was before.

## Motivation:
We have a use case where we run a Mimir cluster exposed through an endpoint fronted by AWS API Gateway, using IAM authentication. We also have multiple Prometheus deployments pushing metrics to Mimir, using IAM credentials.

But without the ability to set the 'service' part of the [signature](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv.html#how-sigv4a-works) in the sigv4 configuration, the requests are forbidden/403. In our specific case 'execute-api' is needed. Though I think other use cases could also make use of this.

@roidelapluie @gotjosh Let me know what you think. Cheers!