### PR TITLE
Chore: Update UTs to validate content of the request body

### DIFF
--- a/sigv4.go
+++ b/sigv4.go
@@ -120,11 +120,16 @@ func (rt *sigV4RoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 	}
 
 	// Ensure our seeker is back at the start of the buffer once we return.
-	var seeker io.ReadSeeker = bytes.NewReader(buf.Bytes())
-	defer func() {
-		_, _ = seeker.Seek(0, io.SeekStart)
-	}()
-	req.Body = io.NopCloser(seeker)
+	// Empty body is a valid situation
+	var seeker io.ReadSeeker = nil
+	if req.Body != nil {
+		seeker = bytes.NewReader(buf.Bytes())
+		bytes.NewReader(buf.Bytes())
+		defer func() {
+			_, _ = seeker.Seek(0, io.SeekStart)
+		}()
+		req.Body = io.NopCloser(seeker)
+	}
 
 	// Clean path like documented in AWS documentation.
 	// https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html

--- a/sigv4_test.go
+++ b/sigv4_test.go
@@ -14,6 +14,7 @@
 package sigv4
 
 import (
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -93,6 +94,10 @@ func TestSigV4RoundTripper(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, gotReq)
 
+		data, err := io.ReadAll(gotReq.Body)
+		require.NoError(t, err)
+		require.Equal(t, "Hello, world!", string(data))
+
 		require.Equal(t, origReq.Header.Get("Authorization"), gotReq.Header.Get("Authorization"))
 	})
 
@@ -105,6 +110,10 @@ func TestSigV4RoundTripper(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, gotReq)
 
+		data, err := io.ReadAll(gotReq.Body)
+		require.NoError(t, err)
+		require.Equal(t, "Hello, world!", string(data))
+
 		require.Equal(t, "/test/test", gotReq.URL.Path)
 	})
 
@@ -112,6 +121,7 @@ func TestSigV4RoundTripper(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, "https://example.com/test/test", nil)
 		require.NoError(t, err)
 		_, err = cli.Do(req)
+		require.Nil(t, req.Body)
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
### What this PR does?

* Update UTs to validate content of the body after we sign the request.
* Fix bug in the handling of the request in case the body is empty. 
   * We can see [here](https://github.com/aws/aws-sdk-go/blob/163aada692ed32951f979aacf452ded4c03b8a7c/aws/signer/v4/v4.go#L711) that the signer is able to handle this situation accordingly.
   * This bug was actually breaking the contract of [RoundTrippers](https://pkg.go.dev/net/http#RoundTripper) because it was modifying the body. Likely this bug was never an issue for Prometheus because the body is always present during remote_write/ sending alerts which is where this is used.