### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,10 @@ version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
-    schedule:
-      interval: monthly
-  - package-ecosystem: "gomod"
-    directory: "/sigv4"
+    groups:
+      aws-sdk-go-v2:
+        patterns:
+          - github.com/aws/aws-sdk-go-v2
+          - github.com/aws/aws-sdk-go-v2/*
     schedule:
       interval: monthly


### PR DESCRIPTION
* Remove unused `/sigv4` config
* Group `github.com/aws/aws-sdk-go-v2` dependencies.