### PR TITLE
feat: add SessionName and Tags support for STS AssumeRole

### DIFF
--- a/sigv4.go
+++ b/sigv4.go
@@ -32,6 +32,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
 )
 
 var sigv4HeaderDenylist = []string{
@@ -51,7 +52,8 @@ type sigV4RoundTripper struct {
 type Option func(*options)
 
 type options struct {
-	ctx context.Context
+	ctx                 context.Context
+	stsEndpointOverride string // for testing: override STS endpoint URL
 }
 
 // WithContext sets the context used during AWS configuration loading
@@ -117,12 +119,31 @@ func NewSigV4RoundTripper(cfg *SigV4Config, next http.RoundTripper, opts ...Opti
 	}
 
 	if cfg.RoleARN != "" {
+		stsOpts := []func(*sts.Options){}
+		if o.stsEndpointOverride != "" {
+			overrideURL := o.stsEndpointOverride
+			stsOpts = append(stsOpts, func(so *sts.Options) {
+				so.BaseEndpoint = aws.String(overrideURL)
+			})
+		}
 		awscfg.Credentials = stscreds.NewAssumeRoleProvider(
-			sts.NewFromConfig(awscfg),
+			sts.NewFromConfig(awscfg, stsOpts...),
 			cfg.RoleARN,
-			func(o *stscreds.AssumeRoleOptions) {
+			func(ao *stscreds.AssumeRoleOptions) {
 				if cfg.ExternalID != "" {
-					o.ExternalID = aws.String(cfg.ExternalID)
+					ao.ExternalID = aws.String(cfg.ExternalID)
+				}
+				if cfg.SessionName != "" {
+					ao.RoleSessionName = cfg.SessionName
+				}
+				if len(cfg.Tags) > 0 {
+					ao.Tags = make([]ststypes.Tag, 0, len(cfg.Tags))
+					for k, v := range cfg.Tags {
+						ao.Tags = append(ao.Tags, ststypes.Tag{
+							Key:   aws.String(k),
+							Value: aws.String(v),
+						})
+					}
 				}
 			},
 		)

--- a/sigv4_config.go
+++ b/sigv4_config.go
@@ -15,22 +15,30 @@ package sigv4
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/prometheus/common/config"
 )
+
+// sessionNamePattern matches the AWS RoleSessionName constraints:
+// 2-64 characters consisting of word characters and +=,.@-
+// See: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
+var sessionNamePattern = regexp.MustCompile(`^[\w+=,.@-]{2,64}$`)
 
 // SigV4Config is the configuration for signing remote write requests with
 // AWS's SigV4 verification process. Empty values will be retrieved using the
 // AWS default credentials chain.
 type SigV4Config struct { //nolint:revive
-	Region             string        `yaml:"region,omitempty"`
-	AccessKey          string        `yaml:"access_key,omitempty"`
-	SecretKey          config.Secret `yaml:"secret_key,omitempty"`
-	Profile            string        `yaml:"profile,omitempty"`
-	RoleARN            string        `yaml:"role_arn,omitempty"`
-	ExternalID         string        `yaml:"external_id,omitempty"`
-	UseFIPSSTSEndpoint bool          `yaml:"use_fips_sts_endpoint,omitempty"`
-	ServiceName        string        `yaml:"service_name,omitempty"`
+	Region             string            `yaml:"region,omitempty"`
+	AccessKey          string            `yaml:"access_key,omitempty"`
+	SecretKey          config.Secret     `yaml:"secret_key,omitempty"`
+	Profile            string            `yaml:"profile,omitempty"`
+	RoleARN            string            `yaml:"role_arn,omitempty"`
+	ExternalID         string            `yaml:"external_id,omitempty"`
+	SessionName        string            `yaml:"session_name,omitempty"`
+	Tags               map[string]string `yaml:"tags,omitempty"`
+	UseFIPSSTSEndpoint bool              `yaml:"use_fips_sts_endpoint,omitempty"`
+	ServiceName        string            `yaml:"service_name,omitempty"`
 }
 
 func (c *SigV4Config) Validate() error {
@@ -39,6 +47,26 @@ func (c *SigV4Config) Validate() error {
 	}
 	if c.ExternalID != "" && c.RoleARN == "" {
 		return fmt.Errorf("external_id can only be used with role_arn")
+	}
+	if c.SessionName != "" && c.RoleARN == "" {
+		return fmt.Errorf("session_name can only be used with role_arn")
+	}
+	if c.SessionName != "" && !sessionNamePattern.MatchString(c.SessionName) {
+		return fmt.Errorf("session_name must match %s (2-64 alphanumeric and +=,.@- characters)", sessionNamePattern.String())
+	}
+	if len(c.Tags) > 0 && c.RoleARN == "" {
+		return fmt.Errorf("tags can only be used with role_arn")
+	}
+	for k, v := range c.Tags {
+		if k == "" {
+			return fmt.Errorf("tag key must not be empty")
+		}
+		if len(k) > 128 {
+			return fmt.Errorf("tag key %q exceeds maximum length of 128", k)
+		}
+		if len(v) > 256 {
+			return fmt.Errorf("tag value for key %q exceeds maximum length of 256", k)
+		}
 	}
 	return nil
 }

--- a/sigv4_config_test.go
+++ b/sigv4_config_test.go
@@ -42,7 +42,11 @@ func testGoodConfig(t *testing.T, filename string) {
 }
 
 func TestGoodSigV4Configs(t *testing.T) {
-	filesToTest := []string{"testdata/sigv4_good.yaml", "testdata/sigv4_good.yaml"}
+	filesToTest := []string{
+		"testdata/sigv4_good.yaml",
+		"testdata/sigv4_good.yaml",
+		"testdata/sigv4_good_session.yaml",
+	}
 	for _, filename := range filesToTest {
 		testGoodConfig(t, filename)
 	}
@@ -63,6 +67,26 @@ func TestBadSigV4Config(t *testing.T) {
 			name:          "external_id without role_arn",
 			filename:      "testdata/sigv4_bad_external_id.yaml",
 			expectedError: "external_id can only be used with role_arn",
+		},
+		{
+			name:          "session_name too short",
+			filename:      "testdata/sigv4_bad_session_too_short.yaml",
+			expectedError: "session_name must match",
+		},
+		{
+			name:          "session_name invalid characters",
+			filename:      "testdata/sigv4_bad_session_pattern.yaml",
+			expectedError: "session_name must match",
+		},
+		{
+			name:          "session_name without role_arn",
+			filename:      "testdata/sigv4_bad_session_no_role.yaml",
+			expectedError: "session_name can only be used with role_arn",
+		},
+		{
+			name:          "tags without role_arn",
+			filename:      "testdata/sigv4_bad_tags_no_role.yaml",
+			expectedError: "tags can only be used with role_arn",
 		},
 	}
 

--- a/sigv4_test.go
+++ b/sigv4_test.go
@@ -15,8 +15,10 @@ package sigv4
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -232,3 +234,190 @@ func TestSigV4RoundTripper(t *testing.T) {
 		}
 	})
 }
+
+// stsAssumeResponse is a minimal STS AssumeRole XML response for tests.
+const stsAssumeResponse = `<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleResult>
+    <Credentials>
+      <AccessKeyId>ASIA_FAKE</AccessKeyId>
+      <SecretAccessKey>FAKE_SECRET</SecretAccessKey>
+      <SessionToken>FAKE_TOKEN</SessionToken>
+      <Expiration>2099-01-01T00:00:00Z</Expiration>
+    </Credentials>
+  </AssumeRoleResult>
+</AssumeRoleResponse>`
+
+// TestAssumeRoleSessionNameAndTags verifies that SessionName and Tags from
+// SigV4Config are threaded through to the STS AssumeRole request body.
+// This mirrors the intent of agentgateway PR #2435: enabling per-caller
+// identity (RoleSessionName) and cost-allocation STS session tags when
+// Prometheus remote-writes through an assumed IAM role.
+func TestAssumeRoleSessionNameAndTags(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "text/xml")
+		_, _ = w.Write([]byte(stsAssumeResponse))
+	}))
+	defer srv.Close()
+
+	cfg := &SigV4Config{
+		Region:      "us-east-1",
+		AccessKey:   "AKIA_FAKE",
+		SecretKey:   "SECRET_FAKE",
+		RoleARN:     "arn:aws:iam::123456789012:role/test-role",
+		SessionName: "prometheus-1",
+		Tags: map[string]string{
+			"team":        "observability",
+			"cost-center": "12345",
+		},
+	}
+
+	// Override STS to hit the mock server.
+	rt, err := NewSigV4RoundTripper(cfg, nil, func(o *options) {
+		o.stsEndpointOverride = srv.URL
+	})
+	require.NoError(t, err)
+
+	// Trigger credential retrieval to force the STS AssumeRole call.
+	creds, err := rt.(*sigV4RoundTripper).creds.Retrieve(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "ASIA_FAKE", creds.AccessKeyID)
+
+	// The mock STS server must have received the AssumeRole body with
+	// the session name and tags.
+	require.Contains(t, gotBody, "RoleSessionName=prometheus-1")
+	require.Contains(t, gotBody, "Tags.member")
+}
+
+// TestAssumeRoleWithExternalIDAndSessionName verifies that ExternalID,
+// SessionName, and Tags all coexist in the AssumeRole request.
+func TestAssumeRoleWithExternalIDAndSessionName(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "text/xml")
+		_, _ = w.Write([]byte(stsAssumeResponse))
+	}))
+	defer srv.Close()
+
+	cfg := &SigV4Config{
+		Region:      "us-east-1",
+		AccessKey:   "AKIA_FAKE",
+		SecretKey:   "SECRET_FAKE",
+		RoleARN:     "arn:aws:iam::123456789012:role/test-role",
+		ExternalID:  "ext-abc-123",
+		SessionName: "prometheus-prod-1",
+		Tags:        map[string]string{"env": "prod"},
+	}
+
+	rt, err := NewSigV4RoundTripper(cfg, nil, func(o *options) {
+		o.stsEndpointOverride = srv.URL
+	})
+	require.NoError(t, err)
+
+	_, err = rt.(*sigV4RoundTripper).creds.Retrieve(t.Context())
+	require.NoError(t, err)
+
+	require.Contains(t, gotBody, "ExternalId=ext-abc-123")
+	require.Contains(t, gotBody, "RoleSessionName=prometheus-prod-1")
+}
+
+// TestValidateSessionNameAndTags exercises the Validate() rules for
+// the new SessionName and Tags fields.
+func TestValidateSessionNameAndTags(t *testing.T) {
+	base := SigV4Config{RoleARN: "arn:aws:iam::123456789012:role/r"}
+
+	tests := []struct {
+		name      string
+		cfg       SigV4Config
+		expectErr string
+	}{
+		{
+			name: "valid session name alphanumeric",
+			cfg:  func() SigV4Config { c := base; c.SessionName = "Prometheus1"; return c }(),
+		},
+		{
+			name: "valid session name special chars",
+			cfg:  func() SigV4Config { c := base; c.SessionName = "user+1@acme.org"; return c }(),
+		},
+		{
+			name: "valid session name min length",
+			cfg:  func() SigV4Config { c := base; c.SessionName = "ab"; return c }(),
+		},
+		{
+			name:      "session_name too short 1 char",
+			cfg:       func() SigV4Config { c := base; c.SessionName = "a"; return c }(),
+			expectErr: "session_name must match",
+		},
+		{
+			name:      "session_name with spaces",
+			cfg:       func() SigV4Config { c := base; c.SessionName = "bad name"; return c }(),
+			expectErr: "session_name must match",
+		},
+		{
+			name:      "session_name with disallowed chars",
+			cfg:       func() SigV4Config { c := base; c.SessionName = "bad!name"; return c }(),
+			expectErr: "session_name must match",
+		},
+		{
+			name:      "session_name too long 65 chars",
+			cfg:       func() SigV4Config { c := base; c.SessionName = strings.Repeat("a", 65); return c }(),
+			expectErr: "session_name must match",
+		},
+		{
+			name: "session_name max length 64 chars",
+			cfg:  func() SigV4Config { c := base; c.SessionName = strings.Repeat("a", 64); return c }(),
+		},
+		{
+			name:      "session_name without role_arn",
+			cfg:       SigV4Config{SessionName: "prometheus-1"},
+			expectErr: "session_name can only be used with role_arn",
+		},
+		{
+			name: "valid tags with role_arn",
+			cfg: func() SigV4Config {
+				c := base
+				c.Tags = map[string]string{"team": "observability"}
+				return c
+			}(),
+		},
+		{
+			name:      "tags without role_arn",
+			cfg:       SigV4Config{Tags: map[string]string{"team": "a"}},
+			expectErr: "tags can only be used with role_arn",
+		},
+		{
+			name: "tag value at max length 256",
+			cfg: func() SigV4Config {
+				c := base
+				c.Tags = map[string]string{"k": strings.Repeat("v", 256)}
+				return c
+			}(),
+		},
+		{
+			name:      "tag value exceeds 256",
+			cfg:       func() SigV4Config { c := base; c.Tags = map[string]string{"k": strings.Repeat("v", 257)}; return c }(),
+			expectErr: "exceeds maximum length of 256",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// ensure json import is used.
+var _ = json.Marshal

--- a/testdata/sigv4_bad_session_no_role.yaml
+++ b/testdata/sigv4_bad_session_no_role.yaml
@@ -1,0 +1,4 @@
+region: us-east-2
+access_key: AccessKey
+secret_key: SecretKey
+session_name: prometheus-1

--- a/testdata/sigv4_bad_session_pattern.yaml
+++ b/testdata/sigv4_bad_session_pattern.yaml
@@ -1,0 +1,5 @@
+region: us-east-2
+access_key: AccessKey
+secret_key: SecretKey
+role_arn: arn:aws:iam::123456789012:role/test-role
+session_name: "bad session name!#$"

--- a/testdata/sigv4_bad_session_too_short.yaml
+++ b/testdata/sigv4_bad_session_too_short.yaml
@@ -1,0 +1,5 @@
+region: us-east-2
+access_key: AccessKey
+secret_key: SecretKey
+role_arn: arn:aws:iam::123456789012:role/test-role
+session_name: "x"

--- a/testdata/sigv4_bad_tags_no_role.yaml
+++ b/testdata/sigv4_bad_tags_no_role.yaml
@@ -1,0 +1,5 @@
+region: us-east-2
+access_key: AccessKey
+secret_key: SecretKey
+tags:
+  team: observability

--- a/testdata/sigv4_good_session.yaml
+++ b/testdata/sigv4_good_session.yaml
@@ -1,0 +1,8 @@
+region: us-east-2
+access_key: AccessKey
+secret_key: SecretKey
+role_arn: arn:aws:iam::123456789012:role/test-role
+session_name: prometheus-instance-1
+tags:
+  team: observability
+  cost-center: "12345"


### PR DESCRIPTION
Add optional SessionName and Tags fields to SigV4Config to enable per-caller identity attribution (RoleSessionName) and cost allocation session tags when assuming IAM roles via STS. This mirrors the capability introduced in agentgateway PR #2435, enabling AWS billing chargeback by team/tenant/environment for Prometheus remote write traffic through assumed roles.

- SessionName validated against AWS constraints: ^[\w+=,.@-]{2,64}$
- Tags validated: key ≤ 128, value ≤ 256, both require role_arn
- SessionName and Tags threaded through to stscreds.AssumeRoleProvider
- New unit tests cover YAML parsing, validation boundary conditions, and end-to-end STS AssumeRole request body verification via mock server